### PR TITLE
Upgrade terraform, vault tf provider and vault server versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ ones:
 
 - docker-compose `1.23.2`  with Compose [file format version](https://github.com/docker/compose/releases) 
 `3.7` support or greater
-- terraform version `0.11.13`
-- vault client/server version `1.1.1`
+- terraform version `0.12.7`
+- vault client/server version `1.2.2`
 
 ## Abstract
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   vault:
-    image: "vault:1.1.1"
+    image: "vault:1.2.2"
     ports:
       - "8200:8200"
     # Allow memory locking

--- a/locals.tf
+++ b/locals.tf
@@ -3,3 +3,4 @@ locals {
     lease_ttl = 2592000 // 30 days
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,18 @@
 // Ensure VAULT_ADDR and VAULT_TOKEN env vars are set
 provider "vault" {
-  version = "1.7.0"
+  version = "2.2.0"
 }
 
 resource "vault_mount" "database" {
   path                      = "database"
   type                      = "database"
-  default_lease_ttl_seconds = "${local.database["lease_ttl"]}"
-  max_lease_ttl_seconds     = "${local.database["lease_ttl"]}"
+  default_lease_ttl_seconds = local.database["lease_ttl"]
+  max_lease_ttl_seconds     = local.database["lease_ttl"]
 }
 
 resource "vault_database_secret_backend_connection" "postgres" {
   allowed_roles = ["service-write", "dev-read"]
-  backend       = "${vault_mount.database.path}"
+  backend       = vault_mount.database.path
   name          = "postgres-secret-backend"
 
   // Needed as SSL is disabled on postgres Docker container
@@ -25,39 +25,43 @@ resource "vault_database_secret_backend_connection" "postgres" {
 }
 
 resource "vault_database_secret_backend_role" "postgres_service_write" {
-  backend = "${vault_mount.database.path}"
+  backend = vault_mount.database.path
   name    = "service-write"
-  db_name = "${vault_database_secret_backend_connection.postgres.name}"
+  db_name = vault_database_secret_backend_connection.postgres.name
 
-  creation_statements = <<EOF
-    CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}';
-    GRANT SELECT,INSERT,UPDATE,DELETE ON ALL TABLES IN SCHEMA public TO "{{name}}";
-  EOF
+  creation_statements = [
+    "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}';",
+    "GRANT SELECT,INSERT,UPDATE,DELETE ON ALL TABLES IN SCHEMA public TO \"{{name}}\";",
+  ]
 
-  revocation_statements = <<EOF
-    REVOKE ALL ON ALL TABLES IN SCHEMA public FROM "{{name}}";
-    DROP ROLE "{{name}}";
-  EOF
+
+  revocation_statements = [
+    "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM \"{{name}}\";",
+    "DROP ROLE \"{{name}}\";",
+  ]
 
   default_ttl = 864000 // 10 days
   max_ttl     = 864000 // 10 days
 }
 
 resource "vault_database_secret_backend_role" "postgres_dev_read" {
-  backend = "${vault_mount.database.path}"
+  backend = vault_mount.database.path
   name    = "dev-read"
-  db_name = "${vault_database_secret_backend_connection.postgres.name}"
+  db_name = vault_database_secret_backend_connection.postgres.name
 
-  creation_statements = <<EOF
-    CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}';
-    GRANT SELECT ON ALL TABLES IN SCHEMA public TO "{{name}}";
-  EOF
+  creation_statements = [
+    "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}';",
+    "GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";",
+  ]
 
-  revocation_statements = <<EOF
-    REVOKE ALL ON ALL TABLES IN SCHEMA public FROM "{{name}}";
-    DROP ROLE "{{name}}";
-  EOF
+
+  revocation_statements = [
+    "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM \"{{name}}\";",
+    "DROP ROLE \"{{name}}\";",
+  ]
+
 
   default_ttl = 2592000 // 30 days
   max_ttl     = 2592000 // 30 days
 }
+

--- a/vars.tf
+++ b/vars.tf
@@ -1,12 +1,15 @@
-variable db {
+variable "db" {
   default = "postgres"
 }
 
-variable db_endpoint {
+variable "db_endpoint" {
   default     = "database:5432"
   description = "DB endpoint from Vault server point of view. Using compose DNS entry"
 }
 
-variable db_password {}
+variable "db_password" {
+}
 
-variable db_user {}
+variable "db_user" {
+}
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Upgrading Terraform version to 0.12.7 as well as the latest version of the Vault terraform provider and Vault server.

Also updated the syntax of the `creation_statements` / `revocation_statements` as I was getting the following error when running `terraform plan` after the upgrade but also using a list of strings is cleaner than here-doc:

```
Error: Incorrect attribute value type

  on main.tf line 33, in resource "vault_database_secret_backend_role" "postgres_service_write":
  32:
  33:     CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}';
  34:

Inappropriate value for attribute "creation_statements": list of string
required.
```

Went through the entire demo using this branch and it all works as expected.